### PR TITLE
Remove keywords for auto-detection of Chai plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   },
   "repository": "https://github.com/originate/lodash-match-pattern",
   "keywords": [
-    "chai",
-    "chai-plugin",
     "checkit",
     "lodash",
     "deep",


### PR DESCRIPTION
These plugins will display this repo on the [Chai Plugins page](http://chaijs.com/plugins/), even though this is not a Chai plugin nor has nothing to do with Chai per se.

At the moment, this needs to be manually filtered out in https://github.com/chaijs/chai-docs/blob/master/_scripts/banned_plugins.js, through https://github.com/chaijs/chai-docs/pull/136.

Cleaning the keywords is a saner solution for both projects :-)
